### PR TITLE
Version 3.0.0-rc1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [v3.0.0-rc1] - WebForms API v1.1.0-1.0.4 - 2024-09-24
+### Changed
+- Added support for version v1.1.0-1.0.4 of the DocuSign WebForms API.
+- Updated the SDK release version.
+
+## Important Action Required
+- User needs to update the base URL in your codebase (if passing to SDK explicitly) and remove the /v1.1 component at the end of the URL for the SDK to work properly with this release.
+
 ## [v2.0.0] - WebForms API v1.1.0-1.0.3 - 2024-07-30
 ### Changed
 - Added support for version v1.1.0-1.0.3 of the DocuSign WebForms API.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This client SDK is provided as open source, which enables you to customize its f
 <a id="versionInformation"></a>
 ### Version Information
 - **API version**: 1.1.0
-- **Latest SDK version (Including prerelease)**: 2.0.0
+- **Latest SDK version (Including prerelease)**: 3.0.0-rc1
 
 <a id="requirements"></a>
 ### Requirements

--- a/SdkTests/SdkNetCoreTests/TestConfig.cs
+++ b/SdkTests/SdkNetCoreTests/TestConfig.cs
@@ -54,7 +54,7 @@ namespace SdkNetCoreTests
             this.IntegratorKeyNoConsent = integratorKeyNoConsentFromEnv;
             this.TemplateId = templateId ?? templateIdFromEnv;
             this.BrandId = brandIdFromEnv;
-            this.Host = host ?? "https://demo.services.docusign.net/webforms/v1.1";
+            this.Host = host ?? "https://demo.services.docusign.net/webforms";
             this.RecipientEmail = recipientEmail ?? "docusignsdktest@mailinator.com";
             this.RecipientName = recipientName ?? "Pat Developer";
             this.TemplateRoleName = templateRoleName ?? "bob";

--- a/SdkTests/SdkTests462/TestConfig.cs
+++ b/SdkTests/SdkTests462/TestConfig.cs
@@ -54,7 +54,7 @@ namespace SdkNetCoreTests
             this.IntegratorKeyNoConsent = integratorKeyNoConsentFromEnv;
             this.TemplateId = templateId ?? templateIdFromEnv;
             this.BrandId = brandIdFromEnv;
-            this.Host = host ?? "https://demo.services.docusign.net/webforms/v1.1";
+            this.Host = host ?? "https://demo.services.docusign.net/webforms";
             this.RecipientEmail = recipientEmail ?? "docusignsdktest@mailinator.com";
             this.RecipientName = recipientName ?? "Pat Developer";
             this.TemplateRoleName = templateRoleName ?? "bob";

--- a/sdk/DocuSign.WebForms.sln
+++ b/sdk/DocuSign.WebForms.sln
@@ -2,7 +2,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
 VisualStudioVersion = 12.0.0.0
 MinimumVisualStudioVersion = 10.0.0.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DocuSign.WebForms", "src\DocuSign.WebForms\DocuSign.WebForms.csproj", "{F45AE3BC-AE47-4BD3-A175-FA68022E34CA}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DocuSign.WebForms", "src\DocuSign.WebForms\DocuSign.WebForms.csproj", "{9CABE8F0-074A-4807-B656-E48BDE003A03}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -10,10 +10,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{F45AE3BC-AE47-4BD3-A175-FA68022E34CA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{F45AE3BC-AE47-4BD3-A175-FA68022E34CA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F45AE3BC-AE47-4BD3-A175-FA68022E34CA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{F45AE3BC-AE47-4BD3-A175-FA68022E34CA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9CABE8F0-074A-4807-B656-E48BDE003A03}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9CABE8F0-074A-4807-B656-E48BDE003A03}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9CABE8F0-074A-4807-B656-E48BDE003A03}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9CABE8F0-074A-4807-B656-E48BDE003A03}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/src/DocuSign.WebForms/Api/FormInstanceManagementApi.cs
+++ b/sdk/src/DocuSign.WebForms/Api/FormInstanceManagementApi.cs
@@ -314,7 +314,7 @@ namespace DocuSign.WebForms.Api
             if (createInstanceBody == null)
                 throw new ApiException(400, "Missing required parameter 'createInstanceBody' when calling FormInstanceManagementApi->CreateInstance");
 
-            var localVarPath = "/accounts/{accountId}/forms/{formId}/instances";
+            var localVarPath = "/v1.1/accounts/{accountId}/forms/{formId}/instances";
             var localVarPathParams = new Dictionary<String, String>();
             var localVarQueryParams = new Dictionary<String, String>();
             var localVarHeaderParams = new Dictionary<String, String>(this.ApiClient.Configuration.DefaultHeader);
@@ -410,7 +410,7 @@ namespace DocuSign.WebForms.Api
             if (createInstanceBody == null)
                 throw new ApiException(400, "Missing required parameter 'createInstanceBody' when calling FormInstanceManagementApi->CreateInstance");
 
-            var localVarPath = "/accounts/{accountId}/forms/{formId}/instances";
+            var localVarPath = "/v1.1/accounts/{accountId}/forms/{formId}/instances";
             var localVarPathParams = new Dictionary<String, String>();
             var localVarQueryParams = new Dictionary<String, String>();
             var localVarHeaderParams = new Dictionary<String, String>(this.ApiClient.Configuration.DefaultHeader);
@@ -507,7 +507,7 @@ namespace DocuSign.WebForms.Api
             if (instanceId == null)
                 throw new ApiException(400, "Missing required parameter 'instanceId' when calling FormInstanceManagementApi->GetInstance");
 
-            var localVarPath = "/accounts/{accountId}/forms/{formId}/instances/{instanceId}";
+            var localVarPath = "/v1.1/accounts/{accountId}/forms/{formId}/instances/{instanceId}";
             var localVarPathParams = new Dictionary<String, String>();
             var localVarQueryParams = new Dictionary<String, String>();
             var localVarHeaderParams = new Dictionary<String, String>(this.ApiClient.Configuration.DefaultHeader);
@@ -596,7 +596,7 @@ namespace DocuSign.WebForms.Api
             if (instanceId == null)
                 throw new ApiException(400, "Missing required parameter 'instanceId' when calling FormInstanceManagementApi->GetInstance");
 
-            var localVarPath = "/accounts/{accountId}/forms/{formId}/instances/{instanceId}";
+            var localVarPath = "/v1.1/accounts/{accountId}/forms/{formId}/instances/{instanceId}";
             var localVarPathParams = new Dictionary<String, String>();
             var localVarQueryParams = new Dictionary<String, String>();
             var localVarHeaderParams = new Dictionary<String, String>(this.ApiClient.Configuration.DefaultHeader);
@@ -691,7 +691,7 @@ namespace DocuSign.WebForms.Api
             if (formId == null)
                 throw new ApiException(400, "Missing required parameter 'formId' when calling FormInstanceManagementApi->ListInstances");
 
-            var localVarPath = "/accounts/{accountId}/forms/{formId}/instances";
+            var localVarPath = "/v1.1/accounts/{accountId}/forms/{formId}/instances";
             var localVarPathParams = new Dictionary<String, String>();
             var localVarQueryParams = new Dictionary<String, String>();
             var localVarHeaderParams = new Dictionary<String, String>(this.ApiClient.Configuration.DefaultHeader);
@@ -780,7 +780,7 @@ namespace DocuSign.WebForms.Api
             if (formId == null)
                 throw new ApiException(400, "Missing required parameter 'formId' when calling FormInstanceManagementApi->ListInstances");
 
-            var localVarPath = "/accounts/{accountId}/forms/{formId}/instances";
+            var localVarPath = "/v1.1/accounts/{accountId}/forms/{formId}/instances";
             var localVarPathParams = new Dictionary<String, String>();
             var localVarQueryParams = new Dictionary<String, String>();
             var localVarHeaderParams = new Dictionary<String, String>(this.ApiClient.Configuration.DefaultHeader);
@@ -873,7 +873,7 @@ namespace DocuSign.WebForms.Api
             if (instanceId == null)
                 throw new ApiException(400, "Missing required parameter 'instanceId' when calling FormInstanceManagementApi->RefreshToken");
 
-            var localVarPath = "/accounts/{accountId}/forms/{formId}/instances/{instanceId}/refresh";
+            var localVarPath = "/v1.1/accounts/{accountId}/forms/{formId}/instances/{instanceId}/refresh";
             var localVarPathParams = new Dictionary<String, String>();
             var localVarQueryParams = new Dictionary<String, String>();
             var localVarHeaderParams = new Dictionary<String, String>(this.ApiClient.Configuration.DefaultHeader);
@@ -962,7 +962,7 @@ namespace DocuSign.WebForms.Api
             if (instanceId == null)
                 throw new ApiException(400, "Missing required parameter 'instanceId' when calling FormInstanceManagementApi->RefreshToken");
 
-            var localVarPath = "/accounts/{accountId}/forms/{formId}/instances/{instanceId}/refresh";
+            var localVarPath = "/v1.1/accounts/{accountId}/forms/{formId}/instances/{instanceId}/refresh";
             var localVarPathParams = new Dictionary<String, String>();
             var localVarQueryParams = new Dictionary<String, String>();
             var localVarHeaderParams = new Dictionary<String, String>(this.ApiClient.Configuration.DefaultHeader);

--- a/sdk/src/DocuSign.WebForms/Api/FormManagementApi.cs
+++ b/sdk/src/DocuSign.WebForms/Api/FormManagementApi.cs
@@ -215,7 +215,7 @@ namespace DocuSign.WebForms.Api
             if (formId == null)
                 throw new ApiException(400, "Missing required parameter 'formId' when calling FormManagementApi->GetForm");
 
-            var localVarPath = "/accounts/{accountId}/forms/{formId}";
+            var localVarPath = "/v1.1/accounts/{accountId}/forms/{formId}";
             var localVarPathParams = new Dictionary<String, String>();
             var localVarQueryParams = new Dictionary<String, String>();
             var localVarHeaderParams = new Dictionary<String, String>(this.ApiClient.Configuration.DefaultHeader);
@@ -304,7 +304,7 @@ namespace DocuSign.WebForms.Api
             if (formId == null)
                 throw new ApiException(400, "Missing required parameter 'formId' when calling FormManagementApi->GetForm");
 
-            var localVarPath = "/accounts/{accountId}/forms/{formId}";
+            var localVarPath = "/v1.1/accounts/{accountId}/forms/{formId}";
             var localVarPathParams = new Dictionary<String, String>();
             var localVarQueryParams = new Dictionary<String, String>();
             var localVarHeaderParams = new Dictionary<String, String>(this.ApiClient.Configuration.DefaultHeader);
@@ -409,7 +409,7 @@ namespace DocuSign.WebForms.Api
             if (accountId == null)
                 throw new ApiException(400, "Missing required parameter 'accountId' when calling FormManagementApi->ListForms");
 
-            var localVarPath = "/accounts/{accountId}/forms";
+            var localVarPath = "/v1.1/accounts/{accountId}/forms";
             var localVarPathParams = new Dictionary<String, String>();
             var localVarQueryParams = new Dictionary<String, String>();
             var localVarHeaderParams = new Dictionary<String, String>(this.ApiClient.Configuration.DefaultHeader);
@@ -498,7 +498,7 @@ namespace DocuSign.WebForms.Api
             if (accountId == null)
                 throw new ApiException(400, "Missing required parameter 'accountId' when calling FormManagementApi->ListForms");
 
-            var localVarPath = "/accounts/{accountId}/forms";
+            var localVarPath = "/v1.1/accounts/{accountId}/forms";
             var localVarPathParams = new Dictionary<String, String>();
             var localVarQueryParams = new Dictionary<String, String>();
             var localVarHeaderParams = new Dictionary<String, String>(this.ApiClient.Configuration.DefaultHeader);

--- a/sdk/src/DocuSign.WebForms/Client/ApiClient.cs
+++ b/sdk/src/DocuSign.WebForms/Client/ApiClient.cs
@@ -22,14 +22,14 @@ namespace DocuSign.WebForms.Client
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiClient" /> class
-        /// with default configuration and base path (https://apps-d.docusign.com/api/webforms/v1.1).
+        /// with default configuration and base path (https://apps-d.docusign.com/api/webforms).
         /// </summary>
         [Obsolete("ApiClient is now obsolete and will be removed in a future release. Use DocuSignClient() instead.", false)]
         public ApiClient() : base() { }
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ApiClient" /> class
-        /// with default base path (https://apps-d.docusign.com/api/webforms/v1.1).
+        /// with default base path (https://apps-d.docusign.com/api/webforms).
         /// </summary>
         /// <param name="configuration">An instance of Configuration.</param>
         [Obsolete("ApiClient is now obsolete and will be removed in a future release. Use DocuSignClient(Configuration) instead.", false)]

--- a/sdk/src/DocuSign.WebForms/Client/Auth/OAuth.cs
+++ b/sdk/src/DocuSign.WebForms/Client/Auth/OAuth.cs
@@ -37,8 +37,6 @@ namespace DocuSign.WebForms.Client.Auth
         public static string Demo_OAuth_BasePath = "account-d.docusign.com";
         // Production server base path
         public static string Production_OAuth_BasePath = "account.docusign.com";
-        // Stage server base path
-        public static string Stage_OAuth_BasePath = "account-s.docusign.com";
 
         //  OAuth ResponseType constants
         //  used by public/native client applications.

--- a/sdk/src/DocuSign.WebForms/Client/Configuration.cs
+++ b/sdk/src/DocuSign.WebForms/Client/Configuration.cs
@@ -26,7 +26,7 @@ namespace DocuSign.WebForms.Client
         /// Version of the package.
         /// </summary>
         /// <value>Version of the package.</value>
-        public const string Version = "2.0.0";
+        public const string Version = "3.0.0-rc1";
 
         /// <summary>
         /// Identifier for ISO 8601 DateTime Format
@@ -115,10 +115,10 @@ namespace DocuSign.WebForms.Client
         /// <summary>
         /// Initializes a new instance of the <see cref="Configuration" /> class
         /// </summary>
-        public Configuration(string basePath = "https://apps-d.docusign.com/api/webforms/v1.1")
+        public Configuration(string basePath = "https://apps-d.docusign.com/api/webforms")
         {
             UserAgent = $"Swagger-Codegen/1.1.0/{Version}/C#/{_getFrameworkVersion()}";
-            BasePath = basePath ?? "https://apps-d.docusign.com/api/webforms/v1.1";
+            BasePath = basePath ?? "https://apps-d.docusign.com/api/webforms";
             DefaultHeader = new ConcurrentDictionary<string, string>();
             ApiKey = new ConcurrentDictionary<string, string>();
             ApiKeyPrefix = new ConcurrentDictionary<string, string>();

--- a/sdk/src/DocuSign.WebForms/Client/DocuSignClient.cs
+++ b/sdk/src/DocuSign.WebForms/Client/DocuSignClient.cs
@@ -40,11 +40,9 @@ namespace DocuSign.WebForms.Client
     {
         // Rest API base path constants
         // Live/Production base path
-        public const string Production_REST_BasePath = "https://us.services.docusign.net/webforms/v1.1";
+        public const string Production_REST_BasePath = "https://us.services.docusign.net/webforms";
         // Sandbox/Demo base path 
-        public const string Demo_REST_BasePath = "https://apps-d.docusign.com/api/webforms/v1.1";
-        // Stage base path
-        public const string Stage_REST_BasePath = "https://apps-s.docusign.com/api/webforms/v1.1";
+        public const string Demo_REST_BasePath = "https://apps-d.docusign.com/api/webforms";
 
         protected string basePath = Demo_REST_BasePath;
 
@@ -82,7 +80,7 @@ namespace DocuSign.WebForms.Client
 
         /// <summary>
         /// Initializes a new instance of <see cref="DocuSignClient"/> with default
-        /// with default base path (https://apps-d.docusign.com/api/webforms/v1.1).
+        /// with default base path (https://apps-d.docusign.com/api/webforms).
         /// </summary>
         public DocuSignClient()
         {
@@ -98,7 +96,7 @@ namespace DocuSign.WebForms.Client
 
         /// <summary>
         /// Initializes a new instance of <see cref="DocuSignClient"/> using
-        /// the provided configuration with the default base path (https://apps-d.docusign.com/api/webforms/v1.1).
+        /// the provided configuration with the default base path (https://apps-d.docusign.com/api/webforms).
         /// </summary>
         /// <param name="configuration">Provided pre-populated <see cref="Configuration"/> object</param>
         public DocuSignClient(Configuration configuration)
@@ -724,10 +722,6 @@ namespace DocuSign.WebForms.Client
                 {
                     this.oAuthBasePath = OAuth.Demo_OAuth_BasePath;
                 }
-                else if (baseUri.Host.StartsWith("apps-s") || baseUri.Host.StartsWith("stage"))
-                {
-                    this.oAuthBasePath = OAuth.Stage_OAuth_BasePath;
-                }
                 else
                 {
                     this.oAuthBasePath = OAuth.Production_OAuth_BasePath;
@@ -913,7 +907,7 @@ namespace DocuSign.WebForms.Client
         /// <param name="clientId">Docusign OAuth Client Id(AKA Integrator Key)</param>
         /// <param name="userId">Docusign user Id to be impersonated(This is a UUID)</param>
         /// <param name="oauthBasePath"> Docusign OAuth base path
-        /// <see cref="OAuth.Demo_OAuth_BasePath"/> <see cref="OAuth.Production_OAuth_BasePath"/> <see cref="OAuth.Stage_OAuth_BasePath"/>
+        /// <see cref="OAuth.Demo_OAuth_BasePath"/> <see cref="OAuth.Production_OAuth_BasePath"/>
         /// <seealso cref="GetOAuthBasePath()" /> <seealso cref="SetOAuthBasePath(string)"/>
         /// </param>
         /// <param name="privateKeyStream">The Stream of the RSA private key</param>
@@ -935,7 +929,7 @@ namespace DocuSign.WebForms.Client
         /// <param name="clientId">Docusign OAuth Client Id(AKA Integrator Key)</param>
         /// <param name="userId">Docusign user Id to be impersonated(This is a UUID)</param>
         /// <param name="oauthBasePath"> Docusign OAuth base path
-        /// <see cref="OAuth.Demo_OAuth_BasePath"/> <see cref="OAuth.Production_OAuth_BasePath"/> <see cref="OAuth.Stage_OAuth_BasePath"/>
+        /// <see cref="OAuth.Demo_OAuth_BasePath"/> <see cref="OAuth.Production_OAuth_BasePath"/>
         /// <seealso cref="GetOAuthBasePath()" /> <seealso cref="SetOAuthBasePath(string)"/>
         /// </param>
         /// <param name="privateKeyStream">The Stream of the RSA private key</param>
@@ -965,7 +959,7 @@ namespace DocuSign.WebForms.Client
         /// <param name="clientId">Docusign OAuth Client Id(AKA Integrator Key)</param>
         /// <param name="userId">Docusign user Id to be impersonated(This is a UUID)</param>
         /// <param name="oauthBasePath"> Docusign OAuth base path
-        /// <see cref="OAuth.Demo_OAuth_BasePath"/> <see cref="OAuth.Production_OAuth_BasePath"/> <see cref="OAuth.Stage_OAuth_BasePath"/>
+        /// <see cref="OAuth.Demo_OAuth_BasePath"/> <see cref="OAuth.Production_OAuth_BasePath"/>
         /// <seealso cref="GetOAuthBasePath()" /> <seealso cref="SetOAuthBasePath(string)"/>
         /// </param>
         /// <param name="privateKeyBytes">The byte contents of the RSA private key</param>
@@ -987,7 +981,7 @@ namespace DocuSign.WebForms.Client
         /// <param name="clientId">Docusign OAuth Client Id(AKA Integrator Key)</param>
         /// <param name="userId">Docusign user Id to be impersonated(This is a UUID)</param>
         /// <param name="oauthBasePath"> Docusign OAuth base path
-        /// <see cref="OAuth.Demo_OAuth_BasePath"/> <see cref="OAuth.Production_OAuth_BasePath"/> <see cref="OAuth.Stage_OAuth_BasePath"/>
+        /// <see cref="OAuth.Demo_OAuth_BasePath"/> <see cref="OAuth.Production_OAuth_BasePath"/>
         /// <seealso cref="GetOAuthBasePath()" /> <seealso cref="SetOAuthBasePath(string)"/>
         /// </param>
         /// <param name="privateKeyBytes">The byte contents of the RSA private key</param>
@@ -1068,7 +1062,7 @@ namespace DocuSign.WebForms.Client
         /// </summary>
         /// <param name="clientId">Docusign OAuth Client Id(AKA Integrator Key)</param>
         /// <param name="oauthBasePath"> Docusign OAuth base path
-        /// <see cref="OAuth.Demo_OAuth_BasePath"/> <see cref="OAuth.Production_OAuth_BasePath"/> <see cref="OAuth.Stage_OAuth_BasePath"/>
+        /// <see cref="OAuth.Demo_OAuth_BasePath"/> <see cref="OAuth.Production_OAuth_BasePath"/>
         /// <seealso cref="GetOAuthBasePath()" /> <seealso cref="SetOAuthBasePath(string)"/>
         /// </param>
         /// <param name="privateKeyBytes">The byte contents of the RSA private key</param>
@@ -1088,7 +1082,7 @@ namespace DocuSign.WebForms.Client
         /// </summary>
         /// <param name="clientId">Docusign OAuth Client Id(AKA Integrator Key)</param>
         /// <param name="oauthBasePath"> Docusign OAuth base path
-        /// <see cref="OAuth.Demo_OAuth_BasePath"/> <see cref="OAuth.Production_OAuth_BasePath"/> <see cref="OAuth.Stage_OAuth_BasePath"/>
+        /// <see cref="OAuth.Demo_OAuth_BasePath"/> <see cref="OAuth.Production_OAuth_BasePath"/>
         /// <seealso cref="GetOAuthBasePath()" /> <seealso cref="SetOAuthBasePath(string)"/>
         /// </param>
         /// <param name="privateKeyBytes">The byte contents of the RSA private key</param>

--- a/sdk/src/DocuSign.WebForms/DocuSign.WebForms.csproj
+++ b/sdk/src/DocuSign.WebForms/DocuSign.WebForms.csproj
@@ -16,7 +16,7 @@
     <RootNamespace>DocuSign.WebForms</RootNamespace>
     <AssemblyName>DocuSign.WebForms</AssemblyName>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <VersionPrefix>3.0.0-rc1</VersionPrefix>
     <VersionSuffix/>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -26,7 +26,7 @@
     <PackageLicenseUrl>https://github.com/docusign/docusign-webforms-csharp-client/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/docusign/docusign-webforms-csharp-client</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageReleaseNotes>[v2.0.0] - WebForms API v1.1.0-1.0.3 - 7/30/2024</PackageReleaseNotes>
+    <PackageReleaseNotes>[v3.0.0-rc1] - WebForms API v1.1.0-1.0.4 - 9/24/2024</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net462'">
     <DefineConstants>NET462</DefineConstants>

--- a/sdk/src/DocuSign.WebForms/Model/InstanceSource.cs
+++ b/sdk/src/DocuSign.WebForms/Model/InstanceSource.cs
@@ -53,7 +53,13 @@ namespace DocuSign.WebForms.Model
         /// Enum UIREMOTE for value: UI_REMOTE
         /// </summary>
         [EnumMember(Value = "UI_REMOTE")]
-        UIREMOTE = 4
+        UIREMOTE = 4,
+        
+        /// <summary>
+        /// Enum WORKFLOW for value: WORKFLOW
+        /// </summary>
+        [EnumMember(Value = "WORKFLOW")]
+        WORKFLOW = 5
     }
 
 }

--- a/sdk/src/DocuSign.WebForms/Model/InstanceStatus.cs
+++ b/sdk/src/DocuSign.WebForms/Model/InstanceStatus.cs
@@ -38,22 +38,28 @@ namespace DocuSign.WebForms.Model
         INITIATED = 1,
         
         /// <summary>
+        /// Enum INPROGRESS for value: IN_PROGRESS
+        /// </summary>
+        [EnumMember(Value = "IN_PROGRESS")]
+        INPROGRESS = 2,
+        
+        /// <summary>
         /// Enum SUBMITTED for value: SUBMITTED
         /// </summary>
         [EnumMember(Value = "SUBMITTED")]
-        SUBMITTED = 2,
+        SUBMITTED = 3,
         
         /// <summary>
         /// Enum EXPIRED for value: EXPIRED
         /// </summary>
         [EnumMember(Value = "EXPIRED")]
-        EXPIRED = 3,
+        EXPIRED = 4,
         
         /// <summary>
         /// Enum FAILED for value: FAILED
         /// </summary>
         [EnumMember(Value = "FAILED")]
-        FAILED = 4
+        FAILED = 5
     }
 
 }

--- a/sdk/src/DocuSign.WebForms/Model/WebForm.cs
+++ b/sdk/src/DocuSign.WebForms/Model/WebForm.cs
@@ -37,7 +37,7 @@ namespace DocuSign.WebForms.Model
         /// </summary>
         /// <param name="VersionId">VersionId.</param>
         /// <param name="FormContent">FormContent.</param>
-        public WebForm(int? VersionId = default(int?), WebFormContent FormContent = default(WebFormContent), string Id = default(string), string AccountId = default(string), bool? IsPublished = default(bool?), bool? IsEnabled = default(bool?), bool? HasDraftChanges = default(bool?), WebFormState? FormState = default(WebFormState?), WebFormProperties FormProperties = default(WebFormProperties), WebFormMetadata FormMetadata = default(WebFormMetadata))
+        public WebForm(int? VersionId = default(int?), WebFormContent FormContent = default(WebFormContent), string Id = default(string), string AccountId = default(string), bool? IsPublished = default(bool?), bool? IsEnabled = default(bool?), bool? IsUploaded = default(bool?), bool? HasDraftChanges = default(bool?), WebFormState? FormState = default(WebFormState?), WebFormProperties FormProperties = default(WebFormProperties), WebFormMetadata FormMetadata = default(WebFormMetadata))
         {
             this.VersionId = VersionId;
             this.FormContent = FormContent;

--- a/sdk/src/DocuSign.WebForms/Model/WebFormMetadata.cs
+++ b/sdk/src/DocuSign.WebForms/Model/WebFormMetadata.cs
@@ -33,15 +33,23 @@ namespace DocuSign.WebForms.Model
         }
 
         /// <summary>
-        /// The source from which the webform is created. Accepted values are [upload, templates, blank]
+        /// The source from which the webform is created. Accepted values are [templates, blank, form]
         /// </summary>
-        /// <value>The source from which the webform is created. Accepted values are [upload, templates, blank]</value>
+        /// <value>The source from which the webform is created. Accepted values are [templates, blank, form]</value>
         [DataMember(Name="source", EmitDefaultValue=false)]
         public WebFormSource? Source { get; set; }
         /// <summary>
+        /// Represents webform type. Possible values are [standalone, hasEsignTemplate]
+        /// </summary>
+        /// <value>Represents webform type. Possible values are [standalone, hasEsignTemplate]</value>
+        [DataMember(Name="type", EmitDefaultValue=false)]
+        public WebFormType? Type { get; set; }
+        /// <summary>
         /// Initializes a new instance of the <see cref="WebFormMetadata" /> class.
         /// </summary>
-        /// <param name="Source">The source from which the webform is created. Accepted values are [upload, templates, blank].</param>
+        /// <param name="Source">The source from which the webform is created. Accepted values are [templates, blank, form].</param>
+        /// <param name="Type">Represents webform type. Possible values are [standalone, hasEsignTemplate].</param>
+        /// <param name="SourceFormId">The source form id from which the webform is created..</param>
         /// <param name="Owner">The user that created the form or has been transferred ownership.</param>
         /// <param name="Sender">The user that has added their consent to the form for sending actions.</param>
         /// <param name="LastModifiedBy">Track the user that last modified anything related to the form.</param>
@@ -61,9 +69,11 @@ namespace DocuSign.WebForms.Model
         /// <param name="LastSenderConsentDateTime">Track the last time a user added their consent for the form..</param>
         /// <param name="PublishedSlug">The public friendly slug that is used to access the form from the player.</param>
         /// <param name="PublishedComponentNames">A dictionary containing the mapping of component names to their respective component types for all the published components..</param>
-        public WebFormMetadata(WebFormSource? Source = default(WebFormSource?), WebFormUserInfo Owner = default(WebFormUserInfo), WebFormUserInfo Sender = default(WebFormUserInfo), WebFormUserInfo LastModifiedBy = default(WebFormUserInfo), WebFormUserInfo FormContentModifiedBy = default(WebFormUserInfo), WebFormUserInfo FormPropertiesModifiedBy = default(WebFormUserInfo), WebFormUserInfo LastPublishedBy = default(WebFormUserInfo), WebFormUserInfo LastEnabledBy = default(WebFormUserInfo), WebFormUserInfo LastDisabledBy = default(WebFormUserInfo), DateTime? ArchivedDateTime = default(DateTime?), DateTime? CreatedDateTime = default(DateTime?), DateTime? LastModifiedDateTime = default(DateTime?), DateTime? FormContentModifiedDateTime = default(DateTime?), DateTime? FormPropertiesModifiedDateTime = default(DateTime?), DateTime? LastPublishedDateTime = default(DateTime?), DateTime? LastEnabledDateTime = default(DateTime?), DateTime? LastDisabledDateTime = default(DateTime?), DateTime? LastSenderConsentDateTime = default(DateTime?), string PublishedSlug = default(string), Dictionary<string, WebFormComponentType> PublishedComponentNames = default(Dictionary<string, WebFormComponentType>))
+        public WebFormMetadata(WebFormSource? Source = default(WebFormSource?), WebFormType? Type = default(WebFormType?), string SourceFormId = default(string), WebFormUserInfo Owner = default(WebFormUserInfo), WebFormUserInfo Sender = default(WebFormUserInfo), WebFormUserInfo LastModifiedBy = default(WebFormUserInfo), WebFormUserInfo FormContentModifiedBy = default(WebFormUserInfo), WebFormUserInfo FormPropertiesModifiedBy = default(WebFormUserInfo), WebFormUserInfo LastPublishedBy = default(WebFormUserInfo), WebFormUserInfo LastEnabledBy = default(WebFormUserInfo), WebFormUserInfo LastDisabledBy = default(WebFormUserInfo), DateTime? ArchivedDateTime = default(DateTime?), DateTime? CreatedDateTime = default(DateTime?), DateTime? LastModifiedDateTime = default(DateTime?), DateTime? FormContentModifiedDateTime = default(DateTime?), DateTime? FormPropertiesModifiedDateTime = default(DateTime?), DateTime? LastPublishedDateTime = default(DateTime?), DateTime? LastEnabledDateTime = default(DateTime?), DateTime? LastDisabledDateTime = default(DateTime?), DateTime? LastSenderConsentDateTime = default(DateTime?), string PublishedSlug = default(string), Dictionary<string, WebFormComponentType> PublishedComponentNames = default(Dictionary<string, WebFormComponentType>))
         {
             this.Source = Source;
+            this.Type = Type;
+            this.SourceFormId = SourceFormId;
             this.Owner = Owner;
             this.Sender = Sender;
             this.LastModifiedBy = LastModifiedBy;
@@ -85,6 +95,12 @@ namespace DocuSign.WebForms.Model
             this.PublishedComponentNames = PublishedComponentNames;
         }
         
+        /// <summary>
+        /// The source form id from which the webform is created.
+        /// </summary>
+        /// <value>The source form id from which the webform is created.</value>
+        [DataMember(Name="sourceFormId", EmitDefaultValue=false)]
+        public string SourceFormId { get; set; }
         /// <summary>
         /// The user that created the form or has been transferred ownership
         /// </summary>
@@ -208,6 +224,8 @@ namespace DocuSign.WebForms.Model
             var sb = new StringBuilder();
             sb.Append("class WebFormMetadata {\n");
             sb.Append("  Source: ").Append(Source).Append("\n");
+            sb.Append("  Type: ").Append(Type).Append("\n");
+            sb.Append("  SourceFormId: ").Append(SourceFormId).Append("\n");
             sb.Append("  Owner: ").Append(Owner).Append("\n");
             sb.Append("  Sender: ").Append(Sender).Append("\n");
             sb.Append("  LastModifiedBy: ").Append(LastModifiedBy).Append("\n");
@@ -267,6 +285,16 @@ namespace DocuSign.WebForms.Model
                     this.Source == other.Source ||
                     this.Source != null &&
                     this.Source.Equals(other.Source)
+                ) && 
+                (
+                    this.Type == other.Type ||
+                    this.Type != null &&
+                    this.Type.Equals(other.Type)
+                ) && 
+                (
+                    this.SourceFormId == other.SourceFormId ||
+                    this.SourceFormId != null &&
+                    this.SourceFormId.Equals(other.SourceFormId)
                 ) && 
                 (
                     this.Owner == other.Owner ||
@@ -378,6 +406,10 @@ namespace DocuSign.WebForms.Model
                 // Suitable nullity checks etc, of course :)
                 if (this.Source != null)
                     hash = hash * 59 + this.Source.GetHashCode();
+                if (this.Type != null)
+                    hash = hash * 59 + this.Type.GetHashCode();
+                if (this.SourceFormId != null)
+                    hash = hash * 59 + this.SourceFormId.GetHashCode();
                 if (this.Owner != null)
                     hash = hash * 59 + this.Owner.GetHashCode();
                 if (this.Sender != null)

--- a/sdk/src/DocuSign.WebForms/Model/WebFormSummary.cs
+++ b/sdk/src/DocuSign.WebForms/Model/WebFormSummary.cs
@@ -44,16 +44,18 @@ namespace DocuSign.WebForms.Model
         /// <param name="AccountId">AccountId.</param>
         /// <param name="IsPublished">Has the form been published.</param>
         /// <param name="IsEnabled">Is the form currently enabled and available for data collection.</param>
+        /// <param name="IsUploaded">Has the form created through upload.</param>
         /// <param name="HasDraftChanges">Does the form have draft changes that need to be published?.</param>
         /// <param name="FormState">FormState.</param>
         /// <param name="FormProperties">FormProperties.</param>
         /// <param name="FormMetadata">FormMetadata.</param>
-        public WebFormSummary(string Id = default(string), string AccountId = default(string), bool? IsPublished = default(bool?), bool? IsEnabled = default(bool?), bool? HasDraftChanges = default(bool?), WebFormState? FormState = default(WebFormState?), WebFormProperties FormProperties = default(WebFormProperties), WebFormMetadata FormMetadata = default(WebFormMetadata))
+        public WebFormSummary(string Id = default(string), string AccountId = default(string), bool? IsPublished = default(bool?), bool? IsEnabled = default(bool?), bool? IsUploaded = default(bool?), bool? HasDraftChanges = default(bool?), WebFormState? FormState = default(WebFormState?), WebFormProperties FormProperties = default(WebFormProperties), WebFormMetadata FormMetadata = default(WebFormMetadata))
         {
             this.Id = Id;
             this.AccountId = AccountId;
             this.IsPublished = IsPublished;
             this.IsEnabled = IsEnabled;
+            this.IsUploaded = IsUploaded;
             this.HasDraftChanges = HasDraftChanges;
             this.FormState = FormState;
             this.FormProperties = FormProperties;
@@ -83,6 +85,12 @@ namespace DocuSign.WebForms.Model
         [DataMember(Name="isEnabled", EmitDefaultValue=false)]
         public bool? IsEnabled { get; set; }
         /// <summary>
+        /// Has the form created through upload
+        /// </summary>
+        /// <value>Has the form created through upload</value>
+        [DataMember(Name="isUploaded", EmitDefaultValue=false)]
+        public bool? IsUploaded { get; set; }
+        /// <summary>
         /// Does the form have draft changes that need to be published?
         /// </summary>
         /// <value>Does the form have draft changes that need to be published?</value>
@@ -110,6 +118,7 @@ namespace DocuSign.WebForms.Model
             sb.Append("  AccountId: ").Append(AccountId).Append("\n");
             sb.Append("  IsPublished: ").Append(IsPublished).Append("\n");
             sb.Append("  IsEnabled: ").Append(IsEnabled).Append("\n");
+            sb.Append("  IsUploaded: ").Append(IsUploaded).Append("\n");
             sb.Append("  HasDraftChanges: ").Append(HasDraftChanges).Append("\n");
             sb.Append("  FormState: ").Append(FormState).Append("\n");
             sb.Append("  FormProperties: ").Append(FormProperties).Append("\n");
@@ -171,6 +180,11 @@ namespace DocuSign.WebForms.Model
                     this.IsEnabled.Equals(other.IsEnabled)
                 ) && 
                 (
+                    this.IsUploaded == other.IsUploaded ||
+                    this.IsUploaded != null &&
+                    this.IsUploaded.Equals(other.IsUploaded)
+                ) && 
+                (
                     this.HasDraftChanges == other.HasDraftChanges ||
                     this.HasDraftChanges != null &&
                     this.HasDraftChanges.Equals(other.HasDraftChanges)
@@ -211,6 +225,8 @@ namespace DocuSign.WebForms.Model
                     hash = hash * 59 + this.IsPublished.GetHashCode();
                 if (this.IsEnabled != null)
                     hash = hash * 59 + this.IsEnabled.GetHashCode();
+                if (this.IsUploaded != null)
+                    hash = hash * 59 + this.IsUploaded.GetHashCode();
                 if (this.HasDraftChanges != null)
                     hash = hash * 59 + this.HasDraftChanges.GetHashCode();
                 if (this.FormState != null)

--- a/sdk/src/DocuSign.WebForms/Model/WebFormType.cs
+++ b/sdk/src/DocuSign.WebForms/Model/WebFormType.cs
@@ -22,32 +22,26 @@ using System.ComponentModel.DataAnnotations;
 namespace DocuSign.WebForms.Model
 {
     /// <summary>
-    /// The source from which the web form is created.
+    /// The field indicates webform type.
     /// </summary>
-    /// <value>The source from which the web form is created.</value>
+    /// <value>The field indicates webform type.</value>
     
     [JsonConverter(typeof(StringEnumConverter))]
     
-    public enum WebFormSource
+    public enum WebFormType
     {
         
         /// <summary>
-        /// Enum Templates for value: templates
+        /// Enum Standalone for value: standalone
         /// </summary>
-        [EnumMember(Value = "templates")]
-        Templates = 1,
+        [EnumMember(Value = "standalone")]
+        Standalone = 1,
         
         /// <summary>
-        /// Enum Blank for value: blank
+        /// Enum HasEsignTemplate for value: hasEsignTemplate
         /// </summary>
-        [EnumMember(Value = "blank")]
-        Blank = 2,
-        
-        /// <summary>
-        /// Enum Form for value: form
-        /// </summary>
-        [EnumMember(Value = "form")]
-        Form = 3
+        [EnumMember(Value = "hasEsignTemplate")]
+        HasEsignTemplate = 2
     }
 
 }

--- a/sdk/src/DocuSign.WebForms/Properties/AssemblyInfo.cs
+++ b/sdk/src/DocuSign.WebForms/Properties/AssemblyInfo.cs
@@ -22,5 +22,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 internal class AssemblyInformation
 {
-    public const string AssemblyInformationalVersion = "2.0.0";
+    public const string AssemblyInformationalVersion = "3.0.0-rc1";
 }


### PR DESCRIPTION
### Changed
- Added support for version v1.1.0-1.0.4 of the DocuSign WebForms API.
- Updated the SDK release version.

## Important Action Required
- User needs to update the base URL in your codebase (if passing to SDK explicitly) and remove the /v1.1 component at the end of the URL for the SDK to work properly with this release.
