### PR TITLE
Version 3.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [v3.0.0] - WebForms API v1.1.0-1.0.4 - 2024-11-05
+### Changed
+- Added support for version v1.1.0-1.0.4 of the DocuSign WebForms API.
+- Updated the SDK release version.
+
+## Important Action Required
+- User needs to update the base URL in your codebase (if passing to SDK explicitly) and remove the /v1.1 component at the end of the URL for the SDK to work properly with this release.
+
 ## [v3.0.0-rc1] - WebForms API v1.1.0-1.0.4 - 2024-09-24
 ### Changed
 - Added support for version v1.1.0-1.0.4 of the DocuSign WebForms API.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This client SDK is provided as open source, which enables you to customize its f
 <a id="versionInformation"></a>
 ### Version Information
 - **API version**: 1.1.0
-- **Latest SDK version (Including prerelease)**: 3.0.0-rc1
+- **Latest SDK version (Including prerelease)**: 3.0.0
 
 <a id="requirements"></a>
 ### Requirements

--- a/sdk/DocuSign.WebForms.sln
+++ b/sdk/DocuSign.WebForms.sln
@@ -2,7 +2,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 2012
 VisualStudioVersion = 12.0.0.0
 MinimumVisualStudioVersion = 10.0.0.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DocuSign.WebForms", "src\DocuSign.WebForms\DocuSign.WebForms.csproj", "{9CABE8F0-074A-4807-B656-E48BDE003A03}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DocuSign.WebForms", "src\DocuSign.WebForms\DocuSign.WebForms.csproj", "{69E7B1BA-FDDE-458A-87EA-B08E50F348AF}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -10,10 +10,10 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{9CABE8F0-074A-4807-B656-E48BDE003A03}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{9CABE8F0-074A-4807-B656-E48BDE003A03}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{9CABE8F0-074A-4807-B656-E48BDE003A03}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{9CABE8F0-074A-4807-B656-E48BDE003A03}.Release|Any CPU.Build.0 = Release|Any CPU
+		{69E7B1BA-FDDE-458A-87EA-B08E50F348AF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{69E7B1BA-FDDE-458A-87EA-B08E50F348AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{69E7B1BA-FDDE-458A-87EA-B08E50F348AF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{69E7B1BA-FDDE-458A-87EA-B08E50F348AF}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sdk/src/DocuSign.WebForms/Client/Configuration.cs
+++ b/sdk/src/DocuSign.WebForms/Client/Configuration.cs
@@ -26,7 +26,7 @@ namespace DocuSign.WebForms.Client
         /// Version of the package.
         /// </summary>
         /// <value>Version of the package.</value>
-        public const string Version = "3.0.0-rc1";
+        public const string Version = "3.0.0";
 
         /// <summary>
         /// Identifier for ISO 8601 DateTime Format

--- a/sdk/src/DocuSign.WebForms/Client/DocuSignClient.cs
+++ b/sdk/src/DocuSign.WebForms/Client/DocuSignClient.cs
@@ -316,6 +316,47 @@ namespace DocuSign.WebForms.Client
         }
 
         /// <summary>
+        /// Parses a CSV-formatted string and converts it into a list of dictionaries,
+        /// where each dictionary represents a record with column headers as keys.
+        /// </summary>
+        /// <param name="content">The CSV-formatted string to be deserialized.</param>
+        /// <returns>A list of dictionaries, each containing key-value pairs of column headers and their corresponding values.</returns>
+        private object DeserializeStringToCsv(string content)
+        {
+            var records = new List<Dictionary<string, object>>();
+
+            // Split the CSV string into lines
+            var lines = content.Split(new[] { '\n' }, StringSplitOptions.RemoveEmptyEntries);
+
+            // Check if there are any lines
+            if (lines.Length > 0)
+            {
+                // Read the header line
+                string[] headers = lines[0].Split(',');
+
+                // Read the rest of the lines
+                for (int i = 1; i < lines.Length; i++)
+                {
+                    string[] values = lines[i].Split(',');
+                    var record = new Dictionary<string, object>();
+
+                    for (int j = 0; j < headers.Length; j++)
+                    {
+                        // Ensure we don't exceed the number of values
+                        if (j < values.Length)
+                        {
+                            record[headers[j]] = values[j]; // Store the value in the dictionary
+                        }
+                    }
+
+                    records.Add(record); // Add the record to the list
+                }
+            }
+
+            return records; // Return the list of records
+        }
+        
+        /// <summary>
         /// Deserialize the JSON string into a proper object.
         /// </summary>
         /// <param name="response">The HTTP response.</param>
@@ -342,6 +383,11 @@ namespace DocuSign.WebForms.Client
             {
                 return ConvertType(response.Content, type);
             }
+
+            if(response.ContentType == "text/csv")
+            {
+                return DeserializeStringToCsv(response.Content);
+            }            
 
             // at this point, it must be a model (json)
             try

--- a/sdk/src/DocuSign.WebForms/DocuSign.WebForms.csproj
+++ b/sdk/src/DocuSign.WebForms/DocuSign.WebForms.csproj
@@ -16,7 +16,7 @@
     <RootNamespace>DocuSign.WebForms</RootNamespace>
     <AssemblyName>DocuSign.WebForms</AssemblyName>
     <NeutralLanguage>en-US</NeutralLanguage>
-    <VersionPrefix>3.0.0-rc1</VersionPrefix>
+    <VersionPrefix>3.0.0</VersionPrefix>
     <VersionSuffix/>
     <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -26,7 +26,7 @@
     <PackageLicenseUrl>https://github.com/docusign/docusign-webforms-csharp-client/blob/master/LICENSE</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/docusign/docusign-webforms-csharp-client</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageReleaseNotes>[v3.0.0-rc1] - WebForms API v1.1.0-1.0.4 - 9/24/2024</PackageReleaseNotes>
+    <PackageReleaseNotes>[v3.0.0] - WebForms API v1.1.0-1.0.4 - 11/5/2024</PackageReleaseNotes>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(TargetFramework)' == 'net462'">
     <DefineConstants>NET462</DefineConstants>

--- a/sdk/src/DocuSign.WebForms/Properties/AssemblyInfo.cs
+++ b/sdk/src/DocuSign.WebForms/Properties/AssemblyInfo.cs
@@ -22,5 +22,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 internal class AssemblyInformation
 {
-    public const string AssemblyInformationalVersion = "3.0.0-rc1";
+    public const string AssemblyInformationalVersion = "3.0.0";
 }


### PR DESCRIPTION
### Changed
- Added support for version v1.1.0-1.0.4 of the DocuSign WebForms API.
- Updated the SDK release version.

## Important Action Required
- User needs to update the base URL in your codebase (if passing to SDK explicitly) and remove the /v1.1 component at the end of the URL for the SDK to work properly with this release.
